### PR TITLE
Integrate Hilt Application and notification permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Permission required for posting notifications on Android 13+ -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
+        android:name=".PawPlanApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/de/lshorizon/pawplan/PawPlanApp.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/PawPlanApp.kt
@@ -1,0 +1,11 @@
+package de.lshorizon.pawplan
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+/**
+ * Main application class that boots Hilt for dependency injection.
+ */
+@HiltAndroidApp
+class PawPlanApp : Application()
+


### PR DESCRIPTION
## Summary
- add `PawPlanApp` Application class with `@HiltAndroidApp`
- register application and notification permission in manifest

## Testing
- `bash gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a202370864832591892200e1a06c51