### PR TITLE
feat: add design theme module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.accompanist.systemuicontroller)
+    implementation(projects.core.design)
     // Local data persistence
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.room.runtime)

--- a/app/src/main/java/de/lshorizon/pawplan/MainActivity.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/MainActivity.kt
@@ -11,8 +11,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import de.lshorizon.pawplan.ui.theme.PawPlanTheme
+import de.lshorizon.pawplan.core.design.PawPlanTheme
 
+/**
+ * Main activity showing a simple greeting within the PawPlan theme.
+ */
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/core/design/build.gradle.kts
+++ b/core/design/build.gradle.kts
@@ -1,0 +1,35 @@
+plugins {
+    id("com.android.library")
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
+}
+
+android {
+    namespace = "de.lshorizon.pawplan.core.design"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.ui)
+    implementation(libs.androidx.ui.graphics)
+    implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.material3)
+    implementation(libs.accompanist.systemuicontroller)
+    debugImplementation(libs.androidx.ui.tooling)
+}

--- a/core/design/src/main/AndroidManifest.xml
+++ b/core/design/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="de.lshorizon.pawplan.core.design" />

--- a/core/design/src/main/kotlin/de/lshorizon/pawplan/core/design/Color.kt
+++ b/core/design/src/main/kotlin/de/lshorizon/pawplan/core/design/Color.kt
@@ -1,0 +1,42 @@
+package de.lshorizon.pawplan.core.design
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+// Color definitions and tokens for PawPlan theme.
+@Immutable
+data class PawColors(
+    val accent: Color,
+    val pageBg: Color,
+    val surface: Color,
+    val surfaceElevated: Color,
+    val divider: Color,
+    val textPrimary: Color,
+    val textMuted: Color,
+    val chipBorder: Color,
+)
+
+val LightPawColors = PawColors(
+    accent = Color(0xFF0A84FF),
+    pageBg = Color(0xFFFFFFFF),
+    surface = Color(0xFFF2F2F7),
+    surfaceElevated = Color(0xFFFFFFFF),
+    divider = Color(0x1F000000),
+    textPrimary = Color(0xFF000000),
+    textMuted = Color(0x99000000),
+    chipBorder = Color(0x33000000),
+)
+
+val DarkPawColors = PawColors(
+    accent = Color(0xFF0A84FF),
+    pageBg = Color(0xFF000000),
+    surface = Color(0xFF1C1C1E),
+    surfaceElevated = Color(0xFF2C2C2E),
+    divider = Color(0x1FFFFFFF),
+    textPrimary = Color(0xFFFFFFFF),
+    textMuted = Color(0x99FFFFFF),
+    chipBorder = Color(0x33FFFFFF),
+)
+
+val LocalPawColors = staticCompositionLocalOf { LightPawColors }

--- a/core/design/src/main/kotlin/de/lshorizon/pawplan/core/design/Shape.kt
+++ b/core/design/src/main/kotlin/de/lshorizon/pawplan/core/design/Shape.kt
@@ -1,0 +1,12 @@
+package de.lshorizon.pawplan.core.design
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+// Shape system defining rounded corners for common surfaces.
+val PawShapes = Shapes(
+    medium = RoundedCornerShape(24.dp),
+    large = RoundedCornerShape(32.dp),
+    extraLarge = RoundedCornerShape(36.dp)
+)

--- a/core/design/src/main/kotlin/de/lshorizon/pawplan/core/design/Theme.kt
+++ b/core/design/src/main/kotlin/de/lshorizon/pawplan/core/design/Theme.kt
@@ -1,0 +1,99 @@
+package de.lshorizon.pawplan.core.design
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+
+// Hosts the app's Material 3 theme and system UI integration.
+@Composable
+fun PawPlanTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val pawColors = if (darkTheme) DarkPawColors else LightPawColors
+    val colorScheme = if (darkTheme) {
+        darkColorScheme(
+            primary = pawColors.accent,
+            background = pawColors.pageBg,
+            surface = pawColors.surface,
+            onPrimary = Color.White,
+            onBackground = pawColors.textPrimary,
+            onSurface = pawColors.textPrimary,
+        )
+    } else {
+        lightColorScheme(
+            primary = pawColors.accent,
+            background = pawColors.pageBg,
+            surface = pawColors.surface,
+            onPrimary = Color.White,
+            onBackground = pawColors.textPrimary,
+            onSurface = pawColors.textPrimary,
+        )
+    }
+
+    val systemUi = rememberSystemUiController()
+    val useDarkIcons = !darkTheme
+    SideEffect {
+        systemUi.setSystemBarsColor(
+            color = pawColors.pageBg,
+            darkIcons = useDarkIcons
+        )
+    }
+
+    CompositionLocalProvider(LocalPawColors provides pawColors) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = PawTypography,
+            shapes = PawShapes,
+            content = content
+        )
+    }
+}
+
+object PawPlanSpacing {
+    // Base spacing unit referenced across layouts.
+    val base = 16.dp
+}
+
+@Preview(name = "Light")
+@Composable
+private fun PawPlanThemePreviewLight() {
+    PawPlanTheme(darkTheme = false) {
+        Surface(
+            modifier = Modifier
+                .size(100.dp)
+                .padding(PawPlanSpacing.base),
+            color = LocalPawColors.current.surface
+        ) {
+            Text("Light", color = LocalPawColors.current.textPrimary)
+        }
+    }
+}
+
+@Preview(name = "Dark", uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun PawPlanThemePreviewDark() {
+    PawPlanTheme(darkTheme = true) {
+        Surface(
+            modifier = Modifier
+                .size(100.dp)
+                .padding(PawPlanSpacing.base),
+            color = LocalPawColors.current.surface
+        ) {
+            Text("Dark", color = LocalPawColors.current.textPrimary)
+        }
+    }
+}

--- a/core/design/src/main/kotlin/de/lshorizon/pawplan/core/design/Type.kt
+++ b/core/design/src/main/kotlin/de/lshorizon/pawplan/core/design/Type.kt
@@ -1,0 +1,6 @@
+package de.lshorizon.pawplan.core.design
+
+import androidx.compose.material3.Typography
+
+// Central typography styles used across the app.
+val PawTypography = Typography()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,4 +25,5 @@ dependencyResolutionManagement {
 
 rootProject.name = "PawPlan"
 include(":app")
+include(":core:design")
  


### PR DESCRIPTION
## Summary
- add core design module with Material3 theme and tokens
- integrate SystemUiController and spacing constants
- wire app module to new theme

## Testing
- `bash gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a204c971f48325bd95523b838710bc