### PR TITLE
Add navigation graph with placeholder screens

### DIFF
--- a/app/src/main/java/de/lshorizon/pawplan/MainActivity.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/MainActivity.kt
@@ -4,17 +4,11 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import de.lshorizon.pawplan.core.design.PawPlanTheme
+import de.lshorizon.pawplan.core.navigation.NavGraph
 
 /**
- * Main activity showing a simple greeting within the PawPlan theme.
+ * Main activity launching the PawPlan navigation graph.
  */
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -22,29 +16,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             PawPlanTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                NavGraph()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    PawPlanTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/de/lshorizon/pawplan/core/navigation/NavGraph.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/core/navigation/NavGraph.kt
@@ -1,0 +1,36 @@
+package de.lshorizon.pawplan.core.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import de.lshorizon.pawplan.ui.screen.AddPetScreen
+import de.lshorizon.pawplan.ui.screen.AddRoutineScreen
+import de.lshorizon.pawplan.ui.screen.HomeScreen
+import de.lshorizon.pawplan.ui.screen.OnboardingScreen
+import de.lshorizon.pawplan.ui.screen.PetsScreen
+import de.lshorizon.pawplan.ui.screen.RoutineScreen
+import de.lshorizon.pawplan.ui.screen.SettingsScreen
+
+/**
+ * Central navigation graph connecting all screens.
+ */
+@Composable
+fun NavGraph(navController: NavHostController = rememberNavController()) {
+    NavHost(
+        navController = navController,
+        startDestination = NavRoutes.Home.route
+    ) {
+        composable(NavRoutes.Home.route) { HomeScreen() }
+        composable(NavRoutes.Pets.route) { PetsScreen() }
+        composable(NavRoutes.AddPet.route) { AddPetScreen() }
+        composable(NavRoutes.AddRoutine.route) { AddRoutineScreen() }
+        composable(NavRoutes.Routine.route) { backStackEntry ->
+            val id = backStackEntry.arguments?.getString("id") ?: ""
+            RoutineScreen(id)
+        }
+        composable(NavRoutes.Settings.route) { SettingsScreen() }
+        composable(NavRoutes.Onboarding.route) { OnboardingScreen() }
+    }
+}

--- a/app/src/main/java/de/lshorizon/pawplan/core/navigation/NavRoutes.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/core/navigation/NavRoutes.kt
@@ -1,0 +1,29 @@
+package de.lshorizon.pawplan.core.navigation
+
+/**
+ * Collection of navigation routes used throughout the app.
+ */
+sealed class NavRoutes(val route: String) {
+    /** Route for the main home screen. */
+    data object Home : NavRoutes("home")
+
+    /** Route displaying the list of pets. */
+    data object Pets : NavRoutes("pets")
+
+    /** Route to add a new pet. */
+    data object AddPet : NavRoutes("addPet")
+
+    /** Route to add a routine. */
+    data object AddRoutine : NavRoutes("addRoutine")
+
+    /** Route to show a specific routine by id. */
+    data object Routine : NavRoutes("routine/{id}") {
+        fun create(id: String) = "routine/$id"
+    }
+
+    /** Route for general settings. */
+    data object Settings : NavRoutes("settings")
+
+    /** Route for the onboarding flow. */
+    data object Onboarding : NavRoutes("onboarding")
+}

--- a/app/src/main/java/de/lshorizon/pawplan/ui/screen/AddPetScreen.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/ui/screen/AddPetScreen.kt
@@ -1,0 +1,12 @@
+package de.lshorizon.pawplan.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+/**
+ * Placeholder screen for adding a new pet.
+ */
+@Composable
+fun AddPetScreen() {
+    Text("Add Pet")
+}

--- a/app/src/main/java/de/lshorizon/pawplan/ui/screen/AddRoutineScreen.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/ui/screen/AddRoutineScreen.kt
@@ -1,0 +1,12 @@
+package de.lshorizon.pawplan.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+/**
+ * Placeholder screen for creating a new routine.
+ */
+@Composable
+fun AddRoutineScreen() {
+    Text("Add Routine")
+}

--- a/app/src/main/java/de/lshorizon/pawplan/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/ui/screen/HomeScreen.kt
@@ -1,0 +1,12 @@
+package de.lshorizon.pawplan.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+/**
+ * Placeholder for the home screen showing a simple heading.
+ */
+@Composable
+fun HomeScreen() {
+    Text("Home")
+}

--- a/app/src/main/java/de/lshorizon/pawplan/ui/screen/OnboardingScreen.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/ui/screen/OnboardingScreen.kt
@@ -1,0 +1,12 @@
+package de.lshorizon.pawplan.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+/**
+ * Placeholder screen for the onboarding flow.
+ */
+@Composable
+fun OnboardingScreen() {
+    Text("Onboarding")
+}

--- a/app/src/main/java/de/lshorizon/pawplan/ui/screen/PetsScreen.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/ui/screen/PetsScreen.kt
@@ -1,0 +1,12 @@
+package de.lshorizon.pawplan.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+/**
+ * Placeholder for the pets screen listing all pets.
+ */
+@Composable
+fun PetsScreen() {
+    Text("Pets")
+}

--- a/app/src/main/java/de/lshorizon/pawplan/ui/screen/RoutineScreen.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/ui/screen/RoutineScreen.kt
@@ -1,0 +1,12 @@
+package de.lshorizon.pawplan.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+/**
+ * Placeholder screen for showing routine details by id.
+ */
+@Composable
+fun RoutineScreen(id: String) {
+    Text("Routine $id")
+}

--- a/app/src/main/java/de/lshorizon/pawplan/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/ui/screen/SettingsScreen.kt
@@ -1,0 +1,12 @@
+package de.lshorizon.pawplan.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+/**
+ * Placeholder for the settings screen.
+ */
+@Composable
+fun SettingsScreen() {
+    Text("Settings")
+}


### PR DESCRIPTION
## Summary
- introduce sealed `NavRoutes` and a central `NavGraph` with home as start
- add simple placeholder screens for home, pets, add pet, add routine, routine, settings and onboarding
- wire MainActivity to launch the new navigation graph within `PawPlanTheme`

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2090cd5848325be7dae910a3a430f