### PR TITLE
Add Room database layer with entities and Hilt integration

### DIFF
--- a/app/src/main/java/de/lshorizon/pawplan/data/local/dao/EventLogDao.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/data/local/dao/EventLogDao.kt
@@ -1,0 +1,37 @@
+package de.lshorizon.pawplan.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import de.lshorizon.pawplan.data.local.entity.EventLogEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Exposes operations for reading and writing event logs.
+ */
+@Dao
+interface EventLogDao {
+    @Query("SELECT * FROM event_logs WHERE id = :id")
+    suspend fun getById(id: String): EventLogEntity?
+
+    @Query("SELECT * FROM event_logs")
+    fun getAll(): Flow<List<EventLogEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: EventLogEntity)
+
+    @Update
+    suspend fun update(entity: EventLogEntity)
+
+    @Delete
+    suspend fun delete(entity: EventLogEntity)
+
+    @Query("SELECT * FROM event_logs WHERE pet_id = :petId")
+    fun byPet(petId: String): Flow<List<EventLogEntity>>
+
+    @Query("SELECT * FROM event_logs WHERE routine_id = :routineId")
+    fun byRoutine(routineId: String): Flow<List<EventLogEntity>>
+}

--- a/app/src/main/java/de/lshorizon/pawplan/data/local/dao/PetDao.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/data/local/dao/PetDao.kt
@@ -1,0 +1,31 @@
+package de.lshorizon.pawplan.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import de.lshorizon.pawplan.data.local.entity.PetEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Provides data access helpers for pets.
+ */
+@Dao
+interface PetDao {
+    @Query("SELECT * FROM pets WHERE id = :id")
+    suspend fun getById(id: String): PetEntity?
+
+    @Query("SELECT * FROM pets")
+    fun getAll(): Flow<List<PetEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: PetEntity)
+
+    @Update
+    suspend fun update(entity: PetEntity)
+
+    @Delete
+    suspend fun delete(entity: PetEntity)
+}

--- a/app/src/main/java/de/lshorizon/pawplan/data/local/dao/RoutineDao.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/data/local/dao/RoutineDao.kt
@@ -1,0 +1,41 @@
+package de.lshorizon.pawplan.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import de.lshorizon.pawplan.data.local.entity.RoutineEntity
+import java.time.Instant
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Handles CRUD operations for routines.
+ */
+@Dao
+interface RoutineDao {
+    @Query("SELECT * FROM routines WHERE id = :id")
+    suspend fun getById(id: String): RoutineEntity?
+
+    @Query("SELECT * FROM routines")
+    fun getAll(): Flow<List<RoutineEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: RoutineEntity)
+
+    @Update
+    suspend fun update(entity: RoutineEntity)
+
+    @Delete
+    suspend fun delete(entity: RoutineEntity)
+
+    @Query("SELECT * FROM routines WHERE next_due <= :until")
+    fun dueUntil(until: Instant): Flow<List<RoutineEntity>>
+
+    @Query("SELECT * FROM routines WHERE pet_id = :petId")
+    fun byPet(petId: String): Flow<List<RoutineEntity>>
+
+    @Query("SELECT * FROM routines WHERE is_active = 1")
+    fun active(): Flow<List<RoutineEntity>>
+}

--- a/app/src/main/java/de/lshorizon/pawplan/data/local/db/AppDatabase.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/data/local/db/AppDatabase.kt
@@ -1,0 +1,38 @@
+package de.lshorizon.pawplan.data.local.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import de.lshorizon.pawplan.data.local.dao.EventLogDao
+import de.lshorizon.pawplan.data.local.dao.PetDao
+import de.lshorizon.pawplan.data.local.dao.RoutineDao
+import de.lshorizon.pawplan.data.local.entity.EventLogEntity
+import de.lshorizon.pawplan.data.local.entity.PetEntity
+import de.lshorizon.pawplan.data.local.entity.RoutineEntity
+
+/**
+ * Central Room database for the app.
+ */
+@Database(
+    entities = [PetEntity::class, RoutineEntity::class, EventLogEntity::class],
+    version = 1
+)
+@TypeConverters(Converters::class)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun petDao(): PetDao
+    abstract fun routineDao(): RoutineDao
+    abstract fun eventLogDao(): EventLogDao
+
+    companion object {
+        /**
+         * Placeholder migration for future schema updates.
+         */
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // no-op for now
+            }
+        }
+    }
+}

--- a/app/src/main/java/de/lshorizon/pawplan/data/local/db/Converters.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/data/local/db/Converters.kt
@@ -1,0 +1,22 @@
+package de.lshorizon.pawplan.data.local.db
+
+import androidx.room.TypeConverter
+import java.time.Instant
+import java.time.LocalDate
+
+/**
+ * Converts complex date types for Room.
+ */
+class Converters {
+    @TypeConverter
+    fun fromInstant(value: Long?): Instant? = value?.let { Instant.ofEpochMilli(it) }
+
+    @TypeConverter
+    fun instantToLong(instant: Instant?): Long? = instant?.toEpochMilli()
+
+    @TypeConverter
+    fun fromLocalDate(value: String?): LocalDate? = value?.let { LocalDate.parse(it) }
+
+    @TypeConverter
+    fun localDateToString(date: LocalDate?): String? = date?.toString()
+}

--- a/app/src/main/java/de/lshorizon/pawplan/data/local/di/DatabaseModule.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/data/local/di/DatabaseModule.kt
@@ -1,0 +1,37 @@
+package de.lshorizon.pawplan.data.local.di
+
+import android.content.Context
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import de.lshorizon.pawplan.data.local.dao.EventLogDao
+import de.lshorizon.pawplan.data.local.dao.PetDao
+import de.lshorizon.pawplan.data.local.dao.RoutineDao
+import de.lshorizon.pawplan.data.local.db.AppDatabase
+import javax.inject.Singleton
+
+/**
+ * Supplies Room database and DAO instances through Hilt.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
+        Room.databaseBuilder(context, AppDatabase::class.java, "app_database")
+            .addMigrations(AppDatabase.MIGRATION_1_2)
+            .build()
+
+    @Provides
+    fun providePetDao(db: AppDatabase): PetDao = db.petDao()
+
+    @Provides
+    fun provideRoutineDao(db: AppDatabase): RoutineDao = db.routineDao()
+
+    @Provides
+    fun provideEventLogDao(db: AppDatabase): EventLogDao = db.eventLogDao()
+}

--- a/app/src/main/java/de/lshorizon/pawplan/data/local/entity/EventLogEntity.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/data/local/entity/EventLogEntity.kt
@@ -1,0 +1,39 @@
+package de.lshorizon.pawplan.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Stores an event that happened to a pet, optionally linked to a routine.
+ */
+@Entity(
+    tableName = "event_logs",
+    foreignKeys = [
+        ForeignKey(
+            entity = PetEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["pet_id"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = RoutineEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["routine_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("pet_id"), Index("routine_id")]
+)
+data class EventLogEntity(
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    @ColumnInfo(name = "pet_id") val petId: String,
+    @ColumnInfo(name = "routine_id") val routineId: String?,
+    val type: String,
+    val timestamp: Instant,
+    @ColumnInfo(name = "meta_json") val metaJson: String? = null
+)

--- a/app/src/main/java/de/lshorizon/pawplan/data/local/entity/PetEntity.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/data/local/entity/PetEntity.kt
@@ -1,0 +1,16 @@
+package de.lshorizon.pawplan.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Represents a single pet stored in the local database.
+ */
+@Entity(tableName = "pets")
+data class PetEntity(
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val birthDate: LocalDate? = null
+)

--- a/app/src/main/java/de/lshorizon/pawplan/data/local/entity/RoutineEntity.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/data/local/entity/RoutineEntity.kt
@@ -1,0 +1,32 @@
+package de.lshorizon.pawplan.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Defines a routine that belongs to a pet and is scheduled locally.
+ */
+@Entity(
+    tableName = "routines",
+    foreignKeys = [
+        ForeignKey(
+            entity = PetEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["pet_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("pet_id")]
+)
+data class RoutineEntity(
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    @ColumnInfo(name = "pet_id") val petId: String,
+    val title: String,
+    @ColumnInfo(name = "next_due") val nextDue: Instant,
+    @ColumnInfo(name = "is_active") val isActive: Boolean = true
+)


### PR DESCRIPTION
## Summary
- add Pet, Routine and EventLog entities with corresponding DAOs
- set up Room AppDatabase with converters and migration stub
- provide database and DAOs through Hilt module

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a20ac3cc0c83258840ad276bc1844a