### PR TITLE
Add routine detail screen with history and actions

### DIFF
--- a/app/src/main/java/de/lshorizon/pawplan/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/ui/screen/home/HomeViewModel.kt
@@ -33,7 +33,7 @@ class HomeViewModel(
     private val listDueRoutines = ListDueRoutines(routineRepo)
     private val listPets = ListPets(petRepo)
     private val markRoutineDone = MarkRoutineDone(routineRepo, eventRepo)
-    private val snoozeRoutine = SnoozeRoutine(routineRepo)
+    private val snoozeRoutine = SnoozeRoutine(routineRepo, eventRepo)
 
     private val _snackbar = MutableSharedFlow<String>()
     val snackbar = _snackbar.asSharedFlow()

--- a/app/src/main/java/de/lshorizon/pawplan/ui/screen/routinedetail/RoutineDetailScreen.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/ui/screen/routinedetail/RoutineDetailScreen.kt
@@ -1,0 +1,165 @@
+package de.lshorizon.pawplan.ui.screen.routinedetail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import de.lshorizon.pawplan.core.data.repo.InMemoryEventLogRepository
+import de.lshorizon.pawplan.core.data.repo.InMemoryPetRepository
+import de.lshorizon.pawplan.core.data.repo.InMemoryRoutineRepository
+import de.lshorizon.pawplan.core.domain.model.EventLog
+import de.lshorizon.pawplan.core.domain.model.Routine
+import de.lshorizon.pawplan.core.domain.usecase.GetHistoryByRoutine
+import de.lshorizon.pawplan.core.domain.usecase.MarkRoutineDone
+import de.lshorizon.pawplan.core.domain.usecase.SnoozeRoutine
+import de.lshorizon.pawplan.core.domain.usecase.ListPets
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Detail view for a single routine showing meta data and action history.
+ */
+@Composable
+fun RoutineDetailScreen(
+    id: Long,
+    viewModel: RoutineDetailViewModel = viewModel(factory = RoutineDetailViewModel.Factory(id)),
+) {
+    val state by viewModel.state.collectAsState()
+    val formatter = DateTimeFormatter.ofPattern("MMM d, HH:mm")
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(state.petName, style = MaterialTheme.typography.titleMedium)
+                Text(state.title, style = MaterialTheme.typography.headlineSmall)
+                Text(state.intervalText, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    "Next due ${state.nextDue.format(formatter)}",
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+        }
+        item {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Button(onClick = { viewModel.markDone() }) { Text("Mark done") }
+                listOf(6L, 24L, 48L).forEach { h ->
+                    Button(onClick = { viewModel.snooze(h) }) { Text("Snooze ${h}h") }
+                }
+            }
+        }
+        item { Text("History", style = MaterialTheme.typography.titleMedium) }
+        items(state.history) { event ->
+            Text(
+                "${event.type} – ${event.timestamp.format(formatter)}",
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+
+/** Holds all data required for [RoutineDetailScreen]. */
+data class RoutineDetailState(
+    val petName: String = "",
+    val title: String = "",
+    val intervalText: String = "",
+    val nextDue: LocalDateTime = LocalDateTime.now(),
+    val history: List<EventLog> = emptyList(),
+)
+
+/** Handles routine actions and exposes its state. */
+class RoutineDetailViewModel(
+    private val id: Long,
+    private val routineRepo: InMemoryRoutineRepository = InMemoryRoutineRepository(),
+    private val petRepo: InMemoryPetRepository = InMemoryPetRepository(),
+    private val eventRepo: InMemoryEventLogRepository = InMemoryEventLogRepository(),
+) : ViewModel() {
+
+    private val markDone = MarkRoutineDone(routineRepo, eventRepo)
+    private val snooze = SnoozeRoutine(routineRepo, eventRepo)
+    private val history = GetHistoryByRoutine(eventRepo)
+    private val listPets = ListPets(petRepo)
+
+    private val routineFlow: Flow<Routine?> =
+        routineRepo.getRoutines().map { list -> list.find { it.id == id } }
+
+    /** State exposed to the UI. */
+    val state: StateFlow<RoutineDetailState> = combine(
+        routineFlow,
+        listPets(),
+        history(id)
+    ) { routine, pets, events ->
+        if (routine == null) RoutineDetailState() else {
+            val pet = pets.find { it.id == routine.petId }
+            val due = computeDueTime(routine)
+            RoutineDetailState(
+                petName = pet?.name ?: "",
+                title = routine.name,
+                intervalText = "Every ${routine.intervalDays} days",
+                nextDue = due,
+                history = events.sortedByDescending { it.timestamp }
+            )
+        }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, RoutineDetailState())
+
+    /** Calculates the next time the routine should run. */
+    private fun computeDueTime(routine: Routine): LocalDateTime {
+        val last = routine.lastDone ?: LocalDateTime.MIN
+        val dueTime = last.plusDays(routine.intervalDays.toLong())
+        val snoozed = routine.snoozedUntil ?: dueTime
+        return if (snoozed.isAfter(dueTime)) snoozed else dueTime
+    }
+
+    fun markDone() {
+        viewModelScope.launch { markDone(id, LocalDateTime.now()) }
+    }
+
+    fun snooze(hours: Long) {
+        viewModelScope.launch { snooze(id, hours) }
+    }
+
+    /** Factory to create [RoutineDetailViewModel] with routine id. */
+    class Factory(private val routineId: Long) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return RoutineDetailViewModel(routineId) as T
+        }
+    }
+}

--- a/core/domain/src/main/kotlin/de/lshorizon/pawplan/core/domain/model/EventLog.kt
+++ b/core/domain/src/main/kotlin/de/lshorizon/pawplan/core/domain/model/EventLog.kt
@@ -3,10 +3,16 @@ package de.lshorizon.pawplan.core.domain.model
 import java.time.LocalDateTime
 
 /**
- * Records when a routine was performed.
+ * Describes an action taken on a routine.
+ */
+enum class EventType { DONE, SNOOZE }
+
+/**
+ * Records when a routine was performed or delayed.
  */
 data class EventLog(
     val id: Long = 0L,
     val routineId: Long,
     val timestamp: LocalDateTime,
+    val type: EventType,
 )

--- a/core/domain/src/main/kotlin/de/lshorizon/pawplan/core/domain/usecase/MarkRoutineDone.kt
+++ b/core/domain/src/main/kotlin/de/lshorizon/pawplan/core/domain/usecase/MarkRoutineDone.kt
@@ -1,6 +1,7 @@
 package de.lshorizon.pawplan.core.domain.usecase
 
 import de.lshorizon.pawplan.core.domain.model.EventLog
+import de.lshorizon.pawplan.core.domain.model.EventType
 import de.lshorizon.pawplan.core.domain.repo.EventLogRepository
 import de.lshorizon.pawplan.core.domain.repo.RoutineRepository
 import java.time.LocalDate
@@ -17,6 +18,6 @@ class MarkRoutineDone(
         require(!now.toLocalDate().isAfter(LocalDate.now())) { "Date must be today or earlier" }
         val routine = routineRepo.getRoutine(id) ?: return
         routineRepo.updateRoutine(routine.copy(lastDone = now, snoozedUntil = null))
-        logRepo.addEvent(EventLog(routineId = id, timestamp = now))
+        logRepo.addEvent(EventLog(routineId = id, timestamp = now, type = EventType.DONE))
     }
 }

--- a/core/domain/src/main/kotlin/de/lshorizon/pawplan/core/domain/usecase/SnoozeRoutine.kt
+++ b/core/domain/src/main/kotlin/de/lshorizon/pawplan/core/domain/usecase/SnoozeRoutine.kt
@@ -1,17 +1,24 @@
 package de.lshorizon.pawplan.core.domain.usecase
 
+import de.lshorizon.pawplan.core.domain.model.EventLog
+import de.lshorizon.pawplan.core.domain.model.EventType
+import de.lshorizon.pawplan.core.domain.repo.EventLogRepository
 import de.lshorizon.pawplan.core.domain.repo.RoutineRepository
 import java.time.LocalDateTime
 
 /**
- * Delays a routine for a number of hours.
+ * Delays a routine for a number of hours and logs the snooze.
  */
-class SnoozeRoutine(private val repo: RoutineRepository) {
-    suspend operator fun invoke(id: Long, hours: Long) {
+class SnoozeRoutine(
+    private val repo: RoutineRepository,
+    private val logRepo: EventLogRepository,
+) {
+    suspend operator fun invoke(id: Long, hours: Long, now: LocalDateTime = LocalDateTime.now()) {
         require(hours > 0) { "Interval must be > 0" }
         val routine = repo.getRoutine(id) ?: return
-        val base = routine.snoozedUntil ?: LocalDateTime.now()
+        val base = routine.snoozedUntil ?: now
         val newTime = base.plusHours(hours)
         repo.updateRoutine(routine.copy(snoozedUntil = newTime))
+        logRepo.addEvent(EventLog(routineId = id, timestamp = now, type = EventType.SNOOZE))
     }
 }


### PR DESCRIPTION
## Summary
- add screen to display routine details with next due time and action history
- log snooze events and mark done events with explicit types
- wire view models to updated use cases

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a221c8faf4832598edfb82d19f2d8d