### PR TITLE
Fix onboarding resources and add DataStore dependency

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,10 +14,12 @@
     <string name="onboarding_allow_notifications">Benachrichtigungen erlauben</string>
     <string name="onboarding_skip">Überspringen</string>
     <string name="onboarding_next">Weiter</string>
-    <string name="onboarding_start">Los geht's</string>
+    <!-- Button label shown on the last onboarding page -->
+    <string name="onboarding_start">Los geht&apos;s</string>
     <string name="onboarding_back_cd">Zurück</string>
     <string name="onboarding_next_cd">Weiter</string>
     <string name="onboarding_skip_cd">Überspringen</string>
-    <string name="onboarding_finish_cd">Los geht's</string>
+    <!-- Content description for finishing onboarding -->
+    <string name="onboarding_finish_cd">Los geht&apos;s</string>
     <string name="onboarding_privacy_settings">Einstellungen öffnen</string>
 </resources>

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -25,6 +25,9 @@ dependencies {
   implementation(projects.core.domain)
   implementation(libs.kotlinx.coroutines.core)
 
+  // Preferences DataStore for simple key-value persistence
+  implementation(libs.androidx.datastore.preferences)
+
   implementation("com.google.dagger:hilt-android:2.52")
   kapt("com.google.dagger:hilt-android-compiler:2.52")
 


### PR DESCRIPTION
## Summary
- escape onboarding button strings to valid XML and document them
- add Android Preferences DataStore dependency to data layer

## Testing
- `./gradlew :core:data:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4610c4fb48325a4b0e5bec5acdf3b