### PR TITLE
Refactor onboarding resources and semantics

### DIFF
--- a/app/src/main/java/de/lshorizon/pawplan/ui/screen/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/de/lshorizon/pawplan/ui/screen/onboarding/OnboardingScreen.kt
@@ -4,7 +4,10 @@ package de.lshorizon.pawplan.ui.screen.onboarding
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,9 +24,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Notifications
-import androidx.compose.material.icons.outlined.Pets
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,11 +33,12 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -46,6 +48,29 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import de.lshorizon.pawplan.R
 import de.lshorizon.pawplan.core.design.PawPlanTheme
 
+/**
+ * Representation of a single static onboarding page using only resource IDs.
+ */
+data class OnboardingPage(
+  @DrawableRes val imageRes: Int,
+  @StringRes val titleRes: Int,
+  @StringRes val subtitleRes: Int
+)
+
+// List of static pages resolved later inside composables
+private val ONBOARDING_PAGES = listOf(
+  OnboardingPage(
+    R.drawable.ic_onboarding_placeholder,
+    R.string.onboarding_welcome_title,
+    R.string.onboarding_welcome_text
+  ),
+  OnboardingPage(
+    R.drawable.ic_onboarding_placeholder,
+    R.string.onboarding_feature_notifications,
+    R.string.onboarding_feature_templates
+  )
+)
+
 /** Onboarding UI with pager and navigation actions. */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -54,14 +79,20 @@ fun OnboardingScreen(
   vm: OnboardingViewModel = hiltViewModel()
 ) {
   val state by vm.uiState.collectAsState()
-  val pages = 4
+  // Count static pages plus dynamic permission and privacy pages
+  val pages = ONBOARDING_PAGES.size + 2
   val pagerState = rememberPagerState(initialPage = state.page, pageCount = { pages })
   LaunchedEffect(state.page) { pagerState.animateScrollToPage(state.page) }
   LaunchedEffect(pagerState.currentPage) { vm.setPage(pagerState.currentPage) }
 
-    val context = LocalContext.current
-    // Static start button text after replacing invalid "{str}" placeholder
-    val startLabel = stringResource(R.string.onboarding_start_label)
+  val context = LocalContext.current
+  // Static start button text after replacing invalid "{str}" placeholder
+  val startLabel = stringResource(R.string.onboarding_start_label)
+  val backCd = stringResource(R.string.onboarding_back_cd)
+  val skipCd = stringResource(R.string.onboarding_skip_cd)
+  val finishCd = stringResource(R.string.onboarding_finish_cd, startLabel)
+  val nextCd = stringResource(R.string.onboarding_next_cd)
+  val buttonCd = if (state.isLast) finishCd else nextCd
 
   Column(modifier = Modifier.fillMaxSize()) {
     Box(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
@@ -69,7 +100,8 @@ fun OnboardingScreen(
         IconButton(
           onClick = { vm.prev() },
           modifier = Modifier.align(Alignment.CenterStart).semantics {
-            contentDescription = stringResource(R.string.onboarding_back_cd)
+            // Describe back navigation for accessibility
+            contentDescription = backCd
           }
         ) { Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null) }
       }
@@ -77,7 +109,8 @@ fun OnboardingScreen(
         TextButton(
           onClick = { vm.skip() },
           modifier = Modifier.align(Alignment.CenterEnd).semantics {
-            contentDescription = stringResource(R.string.onboarding_skip_cd)
+            // Describe skipping action for accessibility
+            contentDescription = skipCd
           }
         ) { Text(stringResource(R.string.onboarding_skip)) }
       }
@@ -85,9 +118,8 @@ fun OnboardingScreen(
 
     HorizontalPager(state = pagerState, modifier = Modifier.weight(1f)) { page ->
       when (page) {
-        0 -> PageWelcome()
-        1 -> PageFeatures()
-        2 -> PageNotifications(
+        in ONBOARDING_PAGES.indices -> OnboardingPageContent(ONBOARDING_PAGES[page])
+        ONBOARDING_PAGES.size -> PageNotifications(
           supported = state.notificationsSupported,
           granted = state.notificationsGranted,
           onRequest = { vm.requestNotifications(context) }
@@ -119,12 +151,8 @@ fun OnboardingScreen(
         .fillMaxWidth()
         .padding(16.dp)
         .semantics {
-          contentDescription = if (state.isLast) {
-            // Describe final action using the dynamic label
-            stringResource(R.string.onboarding_finish_cd, startLabel)
-          } else {
-            stringResource(R.string.onboarding_next_cd)
-          }
+          // Announce the button purpose based on current page
+          contentDescription = buttonCd
         }
     ) {
       Text(
@@ -139,47 +167,22 @@ fun OnboardingScreen(
   }
 }
 
-/** Welcome page introducing the app. */
+/** Displays a static onboarding page based on resource IDs. */
 @Composable
-private fun PageWelcome() {
+private fun OnboardingPageContent(page: OnboardingPage) {
+  val image = painterResource(page.imageRes)
+  val title = stringResource(page.titleRes)
+  val subtitle = stringResource(page.subtitleRes)
   Column(
     modifier = Modifier.fillMaxSize().padding(32.dp),
     verticalArrangement = Arrangement.Center,
     horizontalAlignment = Alignment.CenterHorizontally
   ) {
-    Icon(Icons.Outlined.Pets, contentDescription = null, modifier = Modifier.size(120.dp))
+    Image(painter = image, contentDescription = null, modifier = Modifier.size(120.dp))
     Spacer(Modifier.size(24.dp))
-    Text(stringResource(R.string.onboarding_welcome_title), style = MaterialTheme.typography.headlineMedium)
+    Text(title, style = MaterialTheme.typography.headlineMedium)
     Spacer(Modifier.size(8.dp))
-    Text(stringResource(R.string.onboarding_welcome_text), style = MaterialTheme.typography.bodyMedium, textAlign = TextAlign.Center)
-  }
-}
-
-/** Feature overview page. */
-@Composable
-private fun PageFeatures() {
-  Column(
-    modifier = Modifier.fillMaxSize().padding(32.dp),
-    verticalArrangement = Arrangement.Center,
-    horizontalAlignment = Alignment.Start
-  ) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-      Icon(Icons.Filled.Notifications, contentDescription = null)
-      Spacer(Modifier.size(8.dp))
-      Text(stringResource(R.string.onboarding_feature_notifications))
-    }
-    Spacer(Modifier.size(12.dp))
-    Row(verticalAlignment = Alignment.CenterVertically) {
-      Icon(Icons.Filled.Check, contentDescription = null)
-      Spacer(Modifier.size(8.dp))
-      Text(stringResource(R.string.onboarding_feature_templates))
-    }
-    Spacer(Modifier.size(12.dp))
-    Row(verticalAlignment = Alignment.CenterVertically) {
-      Icon(Icons.Filled.History, contentDescription = null)
-      Spacer(Modifier.size(8.dp))
-      Text(stringResource(R.string.onboarding_feature_history))
-    }
+    Text(subtitle, style = MaterialTheme.typography.bodyMedium, textAlign = TextAlign.Center)
   }
 }
 
@@ -260,8 +263,7 @@ private fun PreviewOnboarding() {
 private fun PreviewPages() {
   PawPlanTheme {
     Column {
-      PageWelcome()
-      PageFeatures()
+      OnboardingPageContent(ONBOARDING_PAGES.first())
       PageNotifications(true, false) {}
       PagePrivacy {}
     }

--- a/app/src/main/res/drawable/ic_onboarding_placeholder.xml
+++ b/app/src/main/res/drawable/ic_onboarding_placeholder.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Simple square placeholder for onboarding images -->
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M0,0h24v24h-24z"/>
+</vector>


### PR DESCRIPTION
## Summary
- model static onboarding pages with resource IDs
- precompute strings for semantics to avoid composable misuse
- add placeholder drawable for onboarding assets

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a474fbfa6c8325825d91b98a42f3ea