### PR TITLE
CI: robust Android SDK setup

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,15 +21,36 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-
-      - name: Set up Android SDK
+      - name: Set up Android SDK (cmdline-tools only)
         uses: android-actions/setup-android@v3
-        with:
-          packages: |
-            platforms;android-33
-            build-tools;33.0.2
-            platform-tools
-            cmdline-tools;latest
+
+      # Installiere SDK-Pakete manuell + akzeptiere Lizenzen (mit Retry & Fallback 34/33)
+      - name: Install SDK packages (retry & fallback)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Lizenzen akzeptieren (idempotent)
+          yes | sdkmanager --licenses || true
+
+          # Mehrfach versuchen, falls Netzwerk zickt
+          attempt() {
+            sdkmanager --install \
+              "platform-tools" \
+              "platforms;android-34" "build-tools;34.0.0" \
+              "platforms;android-33" "build-tools;33.0.2"
+          }
+
+          if ! attempt; then
+            echo "First attempt failed, waiting and retrying..."
+            sleep 10
+            if ! attempt; then
+              echo "Second attempt failed, waiting and retrying..."
+              sleep 20
+              attempt
+            fi
+          fi
+
+          sdkmanager --list || true
 
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3


### PR DESCRIPTION
## Summary
- ensure GitHub Actions installs Android SDK via sdkmanager with retry and fallback for APIs 34/33

## Testing
- `./gradlew assembleDebug test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e324cda8832584074d8c1ed25400