### PR TITLE
ci/compileSdk-36

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,22 +24,19 @@ jobs:
       - name: Set up Android SDK (cmdline-tools only)
         uses: android-actions/setup-android@v3
 
-      # Installiere SDK-Pakete manuell + akzeptiere Lizenzen (mit Retry & Fallback 34/33)
+      # Install SDK packages for API 36 with fallbacks
       - name: Install SDK packages (retry & fallback)
         shell: bash
         run: |
           set -euo pipefail
-          # Lizenzen akzeptieren (idempotent)
           yes | sdkmanager --licenses || true
-
-          # Mehrfach versuchen, falls Netzwerk zickt
           attempt() {
             sdkmanager --install \
               "platform-tools" \
+              "platforms;android-36" \
               "platforms;android-34" "build-tools;34.0.0" \
               "platforms;android-33" "build-tools;33.0.2"
           }
-
           if ! attempt; then
             echo "First attempt failed, waiting and retrying..."
             sleep 10
@@ -49,8 +46,7 @@ jobs:
               attempt
             fi
           fi
-
-          sdkmanager --list || true
+          sdkmanager --list | head -n 200 || true
 
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,12 +12,12 @@ plugins {
 android {
     // Application namespace
     namespace = "de.lshorizon.pawplan"
-    compileSdk = 34 // build against Android 14 (API 34)
+    compileSdk = 36 // Build against Android 15 (API 36) for newer AndroidX
 
     defaultConfig {
         applicationId = "de.lshorizon.pawplan"
         minSdk = 24
-        targetSdk = 34 // target Android 14 APIs
+        targetSdk = 36 // Target Android 15 APIs for compatibility
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
## Summary
- raise app module to compile/target SDK 36 for latest AndroidX
- CI installs android-36 platform with 34/33 fallbacks

## Testing
- `./gradlew assembleDebug test` *(fails: unresolved references in core/domain tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ffdfd49c8325b7dc37fe35f1ac2c