### PR TITLE
ci(android): stabilize SDK setup for CI

### DIFF
--- a/.github/scripts/write-local-properties.sh
+++ b/.github/scripts/write-local-properties.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Helper script to ensure Gradle knows where the Android SDK lives
+set -euxo pipefail
+SDK_ROOT="${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}"
+echo "sdk.dir=${SDK_ROOT}" > local.properties
+echo "wrote local.properties with sdk.dir=${SDK_ROOT}"

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,4 +1,4 @@
-# CI pipeline building and testing the app with Paparazzi snapshots
+# CI pipeline building and testing the app with reliable Android SDK setup
 name: Android CI
 
 on:
@@ -10,6 +10,10 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-24.04
+    env:
+      ANDROID_SDK_ROOT: /usr/local/lib/android/sdk
+      ANDROID_HOME: /usr/local/lib/android/sdk
+      JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
 
     steps:
       - name: Checkout
@@ -18,31 +22,49 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: temurin
+          java-version: "17"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      - name: Install Android SDK tools
-        uses: android-actions/setup-android@v3
-        with:
-          packages: |
-            platform-tools
-            platforms;android-34
-            build-tools;34.0.0
+      # Install commandline tools and ensure sdkmanager works
+      - name: Install Android CMDline tools & accept licenses
+        run: |
+          sudo mkdir -p $ANDROID_SDK_ROOT
+          yes | sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --licenses || true || :
+          # Some runners have an older "latest" alias; install a known good revision and re-run licenses.
+          wget -q https://dl.google.com/android/repository/commandlinetools-linux-12266719_latest.zip -O /tmp/clt.zip
+          sudo unzip -o -q /tmp/clt.zip -d /usr/local/lib/android/
+          sudo rm -rf ${ANDROID_SDK_ROOT}/cmdline-tools/16.0 || true
+          sudo mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools
+          sudo mv /usr/local/lib/android/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/16.0 || true
+          sudo ln -sf ${ANDROID_SDK_ROOT}/cmdline-tools/16.0 ${ANDROID_SDK_ROOT}/cmdline-tools/latest
+          yes | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --licenses
 
-      - name: Accept SDK Licenses
-        run: yes | sdkmanager --licenses
+      # INSTALL PACKAGES AS SEPARATE ARGS (prevents the "combined string" bug)
+      - name: Install Android SDK packages
+        run: |
+          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install \
+            "platform-tools" \
+            "platforms;android-34" \
+            "build-tools;34.0.0"
+          ${ANDROID_SDK_ROOT}/platform-tools/adb --version
+
+      - name: Write local.properties with SDK path
+        run: .github/scripts/write-local-properties.sh
+
+      - name: Grant Gradle wrapper execute permission
+        run: chmod +x ./gradlew
 
       - name: Build (assemble)
-        run: ./gradlew :app:assembleDebug --stacktrace # compile the app
+        run: ./gradlew :app:assembleDebug --stacktrace --no-daemon
 
       - name: Unit tests
-        run: ./gradlew testDebug --stacktrace # execute unit tests
+        run: ./gradlew testDebug --stacktrace --no-daemon
 
       - name: Paparazzi record
-        run: ./gradlew recordPaparazziDebug --stacktrace # generate screenshots
+        run: ./gradlew recordPaparazziDebug --stacktrace --no-daemon
 
       - name: Upload unit test reports
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- add script to generate local.properties from ANDROID_SDK_ROOT
- install Android SDK and packages via sdkmanager with separate args
- set ANDROID_SDK_ROOT/ANDROID_HOME and write local.properties in CI

## Testing
- `./gradlew :app:assembleDebug --stacktrace --no-daemon --console=plain` *(fails: Application class annotated with @HiltAndroidApp must be in android application module)*
- `./gradlew testDebug --stacktrace --no-daemon --console=plain` *(fails: Application class annotated with @HiltAndroidApp must be in android application module)*
- `./gradlew recordPaparazziDebug --stacktrace --no-daemon --console=plain` *(fails: Application class annotated with @HiltAndroidApp must be in android application module)*

------
https://chatgpt.com/codex/tasks/task_e_68a737c5c99c8325970469c47c6f875b