### PR TITLE
Fix Hilt setup and CI pipeline

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,11 +1,9 @@
-# CI pipeline building and testing the app with reliable Android SDK setup
+# CI pipeline ensuring reliable Android SDK setup and tests
 name: Android CI
 
 on:
-  push:
-    branches: [ "**" ]
-  pull_request:
-    branches: [ "**" ]
+  push: { branches: ["**"] }
+  pull_request: { branches: ["**"] }
 
 jobs:
   build-and-test:
@@ -16,59 +14,51 @@ jobs:
       JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: "17"
 
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v3
 
-      # Install commandline tools and ensure sdkmanager works
-      - name: Install Android CMDline tools & accept licenses
+      - name: Install Android cmdline-tools
         run: |
           sudo mkdir -p $ANDROID_SDK_ROOT
-          yes | sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --licenses || true || :
-          # Some runners have an older "latest" alias; install a known good revision and re-run licenses.
           wget -q https://dl.google.com/android/repository/commandlinetools-linux-12266719_latest.zip -O /tmp/clt.zip
           sudo unzip -o -q /tmp/clt.zip -d /usr/local/lib/android/
-          sudo rm -rf ${ANDROID_SDK_ROOT}/cmdline-tools/16.0 || true
           sudo mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools
-          sudo mv /usr/local/lib/android/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/16.0 || true
+          sudo rm -rf ${ANDROID_SDK_ROOT}/cmdline-tools/16.0 || true
+          sudo mv /usr/local/lib/android/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/16.0
           sudo ln -sf ${ANDROID_SDK_ROOT}/cmdline-tools/16.0 ${ANDROID_SDK_ROOT}/cmdline-tools/latest
           yes | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --licenses
 
-      # INSTALL PACKAGES AS SEPARATE ARGS (prevents the "combined string" bug)
-      - name: Install Android SDK packages
+      - name: Install SDK packages
         run: |
-          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install \
-            "platform-tools" \
-            "platforms;android-34" \
-            "build-tools;34.0.0"
+          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "platform-tools" "platforms;android-34" "build-tools;34.0.0"
           ${ANDROID_SDK_ROOT}/platform-tools/adb --version
 
-      - name: Write local.properties with SDK path
-        run: .github/scripts/write-local-properties.sh
+      - name: Write local.properties
+        run: |
+          echo "sdk.dir=${ANDROID_SDK_ROOT}" > local.properties
+          cat local.properties
 
-      - name: Grant Gradle wrapper execute permission
+      - name: Grant Gradle wrapper
         run: chmod +x ./gradlew
 
-      - name: Build (assemble)
-        run: ./gradlew :app:assembleDebug --stacktrace --no-daemon
+      - name: Assemble
+        run: ./gradlew :app:assembleDebug --stacktrace --no-daemon --console=plain
 
       - name: Unit tests
-        run: ./gradlew testDebug --stacktrace --no-daemon
+        run: ./gradlew testDebug --stacktrace --no-daemon --console=plain
 
       - name: Paparazzi record
-        run: ./gradlew recordPaparazziDebug --stacktrace --no-daemon
+        run: ./gradlew recordPaparazziDebug --stacktrace --no-daemon --console=plain
 
       - name: Upload unit test reports
-        uses: actions/upload-artifact@v4
         if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: unit-test-reports
           path: |
@@ -76,8 +66,8 @@ jobs:
             **/build/test-results/testDebugUnitTest/**
 
       - name: Upload Paparazzi screenshots
-        uses: actions/upload-artifact@v4
         if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: ui-screenshots-paparazzi
           path: app/out/paparazzi/**

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,13 +1,12 @@
 plugins {
     // Application and Kotlin plugins with Compose, Hilt and KSP support
-    id("com.android.library")
+    id("com.android.application")
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
     id("androidx.room") version "2.6.1" // enables Room specific Gradle extensions
-    id("app.cash.paparazzi") version "1.3.0" // snapshot testing without an emulator
+    id("app.cash.paparazzi") version "1.3.5" // snapshot testing without an emulator
 }
 
 android {
@@ -16,6 +15,7 @@ android {
     compileSdk = 36 // Build against Android 15 (API 36) for newer AndroidX
 
     defaultConfig {
+        applicationId = "de.lshorizon.pawplan" // unique app identifier
         minSdk = 24
         targetSdk = 36 // Target Android 15 APIs for compatibility
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -48,6 +48,8 @@ android {
     testOptions {
         // Disable animations for stable UI tests
         animationsDisabled = true
+        // Include Android resources for unit tests and Paparazzi
+        unitTests.isIncludeAndroidResources = true
     }
     packaging {
         // Exclude license files required by Compose testing
@@ -81,10 +83,10 @@ dependencies {
     ksp("androidx.room:room-compiler:2.6.1")
     // Dependency injection with Hilt
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     implementation("androidx.hilt:hilt-work:1.2.0")
-    kapt("androidx.hilt:hilt-compiler:1.2.0")
+    ksp("androidx.hilt:hilt-compiler:1.2.0")
     // Background work handling
     implementation("androidx.work:work-runtime-ktx:2.9.1")
     // Extended icon set for pets etc.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <!-- Permission required for posting notifications on Android 13+ -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- Custom application integrates Hilt and WorkManager -->
     <application
         android:name=".PawPlanApp"
         android:allowBackup="true"

--- a/app/src/test/java/de/lshorizon/pawplan/ui/ScreenshotTest.kt
+++ b/app/src/test/java/de/lshorizon/pawplan/ui/ScreenshotTest.kt
@@ -34,6 +34,7 @@ private fun AppPreviewContent() {
     PawPlanTheme {
         OnboardingScreen(
             navController = rememberNavController(),
+            // Create ViewModel with fake repository to avoid DI setup
             vm = OnboardingViewModel(FakePrefsRepository())
         )
     }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -3,8 +3,8 @@
 plugins {
   id("com.android.library")
   kotlin("android")
-  kotlin("kapt")
-  id("com.google.dagger.hilt.android")
+  alias(libs.plugins.ksp) // KSP handles annotation processing
+  id("com.google.dagger.hilt.android") // enables Hilt code generation
 }
 
 android {
@@ -30,8 +30,9 @@ dependencies {
   // Core DataStore library for type-safe storage
   implementation(libs.androidx.datastore.core)
 
-  implementation("com.google.dagger:hilt-android:2.52")
-  kapt("com.google.dagger:hilt-android-compiler:2.52")
+  // Dependency injection with Hilt
+  implementation(libs.hilt.android)
+  ksp(libs.hilt.compiler)
 
   // Library module for data layer
 }


### PR DESCRIPTION
## Summary
- clarify custom Application in manifest
- apply Hilt with KSP in app module and include android resources for unit tests
- switch data module to KSP-based Hilt
- decouple Paparazzi snapshot from DI
- harden Android CI workflow and bump Paparazzi plugin

## Testing
- `./gradlew clean :app:assembleDebug testDebug recordPaparazziDebug --stacktrace --no-daemon` *(fails: build interrupted during execution)*

------
https://chatgpt.com/codex/tasks/task_e_68a741ce1a0083258f8b878f8d56e407