### PR TITLE
ci(android): speed up and stabilize SDK setup

### DIFF
--- a/.github/scripts/install-android-sdk.sh
+++ b/.github/scripts/install-android-sdk.sh
@@ -1,28 +1,28 @@
 #!/usr/bin/env bash
-# Installs Android SDK components for CI builds
+# Installs Android SDK components for CI builds (manual non-interactive setup)
 set -euxo pipefail
-
 export ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}
 export ANDROID_HOME="${ANDROID_SDK_ROOT}"
+
 mkdir -p "${ANDROID_SDK_ROOT}"
 
-# Install specific cmdline-tools revision (known good) and set "latest" symlink
-TMP_ZIP="/tmp/commandlinetools.zip"
-wget -q https://dl.google.com/android/repository/commandlinetools-linux-12266719_latest.zip -O "${TMP_ZIP}"
-unzip -o -q "${TMP_ZIP}" -d /usr/local/lib/android/
+# Known good cmdline-tools revision; install and point "latest" to it
+ZIP=/tmp/clt.zip
+wget -q https://dl.google.com/android/repository/commandlinetools-linux-12266719_latest.zip -O "$ZIP"
+unzip -o -q "$ZIP" -d /usr/local/lib/android/
 mkdir -p "${ANDROID_SDK_ROOT}/cmdline-tools"
 rm -rf "${ANDROID_SDK_ROOT}/cmdline-tools/16.0" || true
 mv /usr/local/lib/android/cmdline-tools "${ANDROID_SDK_ROOT}/cmdline-tools/16.0"
 ln -sfn "${ANDROID_SDK_ROOT}/cmdline-tools/16.0" "${ANDROID_SDK_ROOT}/cmdline-tools/latest"
 
-# Accept all licenses non-interactively
+# Accept licenses non-interactively
 yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null
 
-# Install REQUIRED packages as SEPARATE arguments (no newlines bug)
+# Install REQUIRED packages as SEPARATE arguments (prevents newline token bug)
 "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --install \
   "platform-tools" \
   "platforms;android-34" \
   "build-tools;34.0.0"
 
-# Sanity check
+# Sanity
 "${ANDROID_SDK_ROOT}/platform-tools/adb" --version

--- a/.github/scripts/write-local-properties.sh
+++ b/.github/scripts/write-local-properties.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Generates local.properties so Gradle finds the Android SDK
 set -euxo pipefail
-SDK_ROOT="${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}"
-echo "sdk.dir=${SDK_ROOT}" > local.properties
+SDK="${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}"
+echo "sdk.dir=${SDK}" > local.properties
 cat local.properties

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -2,42 +2,49 @@
 name: Android CI
 
 on:
-  push:
-    branches: ["**"]
-  pull_request:
-    branches: ["**"]
+  push: { branches: ["**"] }
+  pull_request: { branches: ["**"] }
+
+concurrency:
+  group: android-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-test:
+  build-test-screens:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     env:
       ANDROID_SDK_ROOT: /usr/local/lib/android/sdk
       ANDROID_HOME: /usr/local/lib/android/sdk
       JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx3g -XX:+UseParallelGC" -Dorg.gradle.vfs.watch=false
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: "17"
 
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v3
 
-      - name: Install Android SDK (manual & robust)
+      # Manual SDK setup (avoid newline package bug & interactive prompts)
+      - name: Install Android SDK (manual)
         run: .github/scripts/install-android-sdk.sh
 
-      - name: Write local.properties with SDK path
+      - name: Write local.properties
         run: .github/scripts/write-local-properties.sh
 
-      - name: Grant Gradle wrapper execution
+      - name: Grant Gradle wrapper
         run: chmod +x ./gradlew
 
-      - name: Assemble
+      # Warm up dependencies to avoid long first-run stalls
+      - name: Gradle warmup (help)
+        run: ./gradlew -q help
+
+      - name: Assemble debug
         run: ./gradlew :app:assembleDebug --stacktrace --no-daemon --console=plain
 
       - name: Unit tests


### PR DESCRIPTION
## Summary
- install Android SDK manually via script to avoid newline package bug and license prompts
- create local.properties helper script so Gradle always finds the SDK
- overhaul CI workflow: manual SDK install, gradle warmup, build/tests/paparazzi and artifact uploads

## Testing
- `./gradlew -q help`
- `./gradlew :app:assembleDebug --stacktrace --no-daemon --console=plain`
- `./gradlew testDebug --stacktrace --no-daemon --console=plain` *(fails: org.gradle.api.internal.tasks.testing.junit.result.TestFailure)*
- `./gradlew recordPaparazziDebug --stacktrace --no-daemon --console=plain` *(fails: org.gradle.api.internal.tasks.testing.junit.result.TestFailure)*

------
https://chatgpt.com/codex/tasks/task_e_68a74f17c660832590c815e1c39510f9