### PR TITLE
CI: deterministic Android SDK install + stable unit/Paparazzi tests

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,115 +1,139 @@
 name: Android CI
 
 on:
-  push: { branches: ["**"] }
-  pull_request: { branches: ["**"] }
-
-concurrency:
-  group: android-${{ github.ref }}
-  cancel-in-progress: true
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
 
 jobs:
-  build-test-screens:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 60
+  test:
+    runs-on: ubuntu-latest
     env:
-      ANDROID_SDK_ROOT: /usr/local/lib/android/sdk
+      # Will be set once we detect the gradle root
+      GRADLEW_DIR: .
       ANDROID_HOME: /usr/local/lib/android/sdk
-      JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
-      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx3g -XX:+UseParallelGC" -Dorg.gradle.vfs.watch=false
-
+      ANDROID_SDK_ROOT: /usr/local/lib/android/sdk
+      # Speed up Gradle & make logs plain
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.daemon.jvm.options="-Xmx1g"
     steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: "17"
 
-      - uses: gradle/actions/setup-gradle@v3
-
-      # -------- Detect project directory (holds settings.gradle / settings.gradle.kts)
-      - name: Detect Gradle project dir
-        id: pd
+      - name: Detect Gradle wrapper directory
+        id: findroot
         shell: bash
         run: |
-          set -euxo pipefail
-          ROOT="$GITHUB_WORKSPACE"
-          CANDIDATE="$ROOT"
-          if [ ! -f "$ROOT/settings.gradle" ] && [ ! -f "$ROOT/settings.gradle.kts" ]; then
-            # search max depth 2 to avoid monorepo surprises
-            FOUND=$(find "$ROOT" -maxdepth 2 -type f \( -name "settings.gradle" -o -name "settings.gradle.kts" \) -printf "%h\n" | head -n1 || true)
-            if [ -n "$FOUND" ]; then
-              CANDIDATE="$FOUND"
+          if [ -f "gradlew" ]; then
+            echo "GRADLEW_DIR=." >> $GITHUB_ENV
+          else
+            WRAP=$(git ls-files | grep -E '/gradlew$' | head -n1 || true)
+            if [ -z "$WRAP" ]; then
+              echo "Gradle wrapper not found"; exit 1
             fi
+            DIR=$(dirname "$WRAP")
+            echo "GRADLEW_DIR=$DIR" >> $GITHUB_ENV
           fi
-          echo "PROJECT_DIR=$CANDIDATE" >> $GITHUB_ENV
-          echo "Detected PROJECT_DIR=$CANDIDATE"
+          echo "Gradle at: $GRADLEW_DIR"
 
-      # -------- Install Android SDK manually (no interactive prompts)
-      - name: Install Android SDK (manual)
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*','**/gradle.properties','**/settings.gradle*') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      # ---------- ANDROID SDK (manual, deterministic) ----------
+      - name: Install Android SDK commandline-tools (latest 12.x)
         shell: bash
         run: |
-          set -euxo pipefail
-          SDK="$ANDROID_SDK_ROOT"
-          mkdir -p "$SDK"
-          ZIP=/tmp/clt.zip
-          wget -q https://dl.google.com/android/repository/commandlinetools-linux-12266719_latest.zip -O "$ZIP"
-          unzip -o -q "$ZIP" -d /usr/local/lib/android/
-          mkdir -p "$SDK/cmdline-tools"
-          rm -rf "$SDK/cmdline-tools/16.0" || true
-          mv /usr/local/lib/android/cmdline-tools "$SDK/cmdline-tools/16.0"
-          ln -sfn "$SDK/cmdline-tools/16.0" "$SDK/cmdline-tools/latest"
-          yes | "$SDK/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null
-          "$SDK/cmdline-tools/latest/bin/sdkmanager" --install "platform-tools" "platforms;android-34" "build-tools;34.0.0"
-          "$SDK/platform-tools/adb" version
+          set -euo pipefail
+          mkdir -p "$ANDROID_HOME"/cmdline-tools
+          # Use a fixed, working revision to avoid preview regressions
+          URL="https://dl.google.com/android/repository/commandlinetools-linux-12266719_latest.zip"
+          curl -sSL "$URL" -o /tmp/cmdtools.zip
+          unzip -o -q /tmp/cmdtools.zip -d /tmp/cmdtools
+          # Place under cmdline-tools/16.0 so sdkmanager path is stable
+          rm -rf "$ANDROID_HOME/cmdline-tools/16.0"
+          mkdir -p "$ANDROID_HOME/cmdline-tools/16.0"
+          mv /tmp/cmdtools/* "$ANDROID_HOME/cmdline-tools/16.0/"
+          echo "$ANDROID_HOME/cmdline-tools/16.0/bin" >> $GITHUB_PATH
 
-      # -------- Write local.properties into the detected PROJECT_DIR
-      - name: Write local.properties
+      - name: Accept SDK licenses non-interactively
+        shell: bash
+        run: yes | "$ANDROID_HOME/cmdline-tools/16.0/bin/sdkmanager" --licenses > /dev/null
+
+      - name: Install required SDK packages
         shell: bash
         run: |
-          set -euxo pipefail
-          echo "sdk.dir=$ANDROID_SDK_ROOT" > "$PROJECT_DIR/local.properties"
-          cat "$PROJECT_DIR/local.properties"
+          set -euo pipefail
+          PKGS=(
+            "platform-tools"
+            "platforms;android-34"
+            "build-tools;34.0.0"
+          )
+          "$ANDROID_HOME/cmdline-tools/16.0/bin/sdkmanager" "${PKGS[@]}"
+          "$ANDROID_HOME/platform-tools/adb" version
 
-      - name: Make gradlew executable
-        working-directory: ${{ env.PROJECT_DIR }}
-        run: chmod +x ./gradlew
+      - name: Write local.properties pointing to SDK
+        working-directory: ${{ env.GRADLEW_DIR }}
+        shell: bash
+        run: |
+          printf "sdk.dir=%s\n" "$ANDROID_HOME" > local.properties
+          cat local.properties
 
-      - name: Gradle warmup
-        working-directory: ${{ env.PROJECT_DIR }}
+      # ---------- BUILD & TEST ----------
+      - name: Gradle help (smoke)
+        working-directory: ${{ env.GRADLEW_DIR }}
+        shell: bash
         run: ./gradlew -q help
 
-      - name: Assemble :app
-        working-directory: ${{ env.PROJECT_DIR }}
-        run: ./gradlew :app:assembleDebug --stacktrace --no-daemon --console=plain
-
-      - name: Unit tests (verbose, non-fatal)
-        working-directory: ${{ env.PROJECT_DIR }}
+      - name: Unit tests
+        working-directory: ${{ env.GRADLEW_DIR }}
+        shell: bash
         run: |
-          set +e
-          ./gradlew :app:testDebugUnitTest --stacktrace --info --no-daemon --console=plain
-          exit 0
+          set -e
+          # Try :app: first, else fall back to global task
+          if ./gradlew -q projects | grep -qE "Project ':[Aa]pp'"; then
+            ./gradlew :app:testDebugUnitTest --stacktrace --info --console=plain
+          else
+            ./gradlew testDebugUnitTest --stacktrace --info --console=plain
+          fi
 
-      - name: Paparazzi record (verbose)
-        working-directory: ${{ env.PROJECT_DIR }}
-        run: ./gradlew :app:recordPaparazziDebug --stacktrace --info --no-daemon --console=plain
+      - name: Paparazzi record (if available)
+        working-directory: ${{ env.GRADLEW_DIR }}
+        shell: bash
+        run: |
+          set -e
+          if ./gradlew tasks | grep -q "recordPaparazziDebug"; then
+            ./gradlew recordPaparazziDebug --stacktrace --info --console=plain
+          else
+            echo "Paparazzi task not present; skipping."
+          fi
 
-      - name: Upload unit test reports
+      # ---------- ARTIFACTS ----------
+      - name: Collect test reports
+        if: always()
+        shell: bash
+        working-directory: ${{ env.GRADLEW_DIR }}
+        run: |
+          mkdir -p ci-artifacts
+          find . -type d -path "*/build/reports/tests" -exec bash -c 'for d; do dest="ci-artifacts/$(echo "$d" | sed "s#^\./##;s#/#__#g")"; mkdir -p "$dest"; cp -r "$d"/* "$dest"/; done' bash {} +
+          find . -type d -path "*/build/reports/paparazzi" -exec bash -c 'for d; do dest="ci-artifacts/$(echo "$d" | sed "s#^\./##;s#/#__#g")"; mkdir -p "$dest"; cp -r "$d"/* "$dest"/; done' bash {} +
+
+      - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: unit-test-reports
-          path: |
-            ${{ env.PROJECT_DIR }}/**/build/reports/tests/testDebugUnitTest/**
-            ${{ env.PROJECT_DIR }}/**/build/test-results/testDebugUnitTest/**
-
-      - name: Upload Paparazzi screenshots
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ui-screenshots-paparazzi
-          path: |
-            ${{ env.PROJECT_DIR }}/**/out/paparazzi/**
-            ${{ env.PROJECT_DIR }}/**/build/paparazzi/**
+          name: android-reports
+          path: ${{ env.GRADLEW_DIR }}/ci-artifacts
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- install Android SDK manually with fixed commandline tools
- cache Gradle and run unit tests plus optional Paparazzi
- collect test and screenshot reports as workflow artifacts

## Testing
- `./gradlew -q help`
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a762e665e48325ba2a1faf95a5afc6